### PR TITLE
Adding support for CUDA in aarch64

### DIFF
--- a/org.freedesktop.Sdk.Extension.llvm15.json
+++ b/org.freedesktop.Sdk.Extension.llvm15.json
@@ -90,7 +90,7 @@
             "cxxflags": "-Qunused-arguments",
             "config-opts": [
               "-DLLVM_DEFAULT_TARGET_TRIPLE=aarch64-unknown-linux-gnu",
-              "-DLLVM_TARGETS_TO_BUILD='AArch64;WebAssembly'"
+              "-DLLVM_TARGETS_TO_BUILD='AArch64;NVPTX;WebAssembly'"
             ]
           },
           "x86_64": {


### PR DESCRIPTION
Adding support for CUDA in aarch64, given that production drivers are now supported in aarch64.

https://github.com/flathub/org.freedesktop.Platform.GL.nvidia/pull/148